### PR TITLE
pre-install: use find-exe-path instead of 'type mutt ....'

### DIFF
--- a/private/pre-install.rkt
+++ b/private/pre-install.rkt
@@ -31,7 +31,7 @@
 ;; Check for `mutt` executable,
 ;;  raise error if it's not found
 (define (check-mutt)
-  (unless (system "type mutt >& /dev/null")
+  (unless (find-executable-path "mutt")
     (raise-user-error errloc "could not locate `mutt` executable, install with your package manager and try again")))
 
 ;; Check for a mailbox folder


### PR DESCRIPTION
@LeifAndersen can you run these 2 commands for me:

```
> (system "type mutt >& /dev/null")
> (find-executable-path "mutt")
```

I expect the 1st one to fail and the 2nd to pass.
If so, I'll merge this and you should be OK.

- - -

From #13 it looks like `system` on your system is using `sh` and therefore the redirect `>&` isn't working.
(Even if that's not the problem, my code should be using `find-executable-path` anyway.)