### PR TITLE
mutt: escape quotes in apostrophes and titles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION=6.7
     - RACKET_VERSION=HEAD
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - RACKET_DIR=~/racket
   matrix:
-    - RACKET_VERSION=6.6
+    - RACKET_VERSION=6.7
     - RACKET_VERSION=HEAD
 
 before_install:

--- a/info.rkt
+++ b/info.rkt
@@ -1,9 +1,9 @@
 #lang info
 (define collection "mutt")
-(define deps '("base" "typed-racket-lib" "typed-racket-more"))
+(define deps '("base" "typed-racket-lib" "typed-racket-more" "make-log-interceptor"))
 (define build-deps '("scribble-lib" "racket-doc" "rackunit-lib" "rackunit-abbrevs" "typed-racket-doc"))
 (define pkg-desc "API for the Mutt email client")
-(define version "0.2")
+(define version "0.3")
 (define pkg-authors '(ben))
 (define scribblings '(("scribblings/mutt.scrbl" () ("Email"))))
 (define pre-install-collection "private/pre-install.rkt")

--- a/test/untyped.rkt
+++ b/test/untyped.rkt
@@ -3,6 +3,7 @@
 
   (require
     mutt
+    mutt/test/util
     rackunit
     rackunit-abbrevs
     racket/string
@@ -17,26 +18,33 @@
         (f arg* ...))
       (let ([actual (get-output-string p)])
         (close-output-port p)
-        (check-equal? (string-split actual) expected))))
-
-  (define email_addrs "./email_addrs.txt")
-  (define sample_msg  "./sample_message.txt")
+        (check str+rx*=? (string-split actual) expected))))
 
   (test-case "mutt"
     (check-mutt [mutt "hello" #:to "adam@west.co" #:subject "hi"]
-                '("-shi" "adam@west.co" "hello"))
+                `("-s" "hi" "adam@west.co" "hello"))
     (check-mutt [mutt "bye" #:to "mae@west.it" #:subject "yo" #:cc "a@a.a"]
-                '("-syo" "-c" "a@a.a" "mae@west.it" "bye"))
+                `("-s" "yo" "-c" "a@a.a" "mae@west.it" "bye"))
     (check-mutt [mutt "yes" #:to "felix@cat.ct" #:subject "--" #:cc '("mr@dont.play") #:bcc '("we@pa.com" "www@dotcom.com")]
-                '("-s--" "-c" "mr@dont.play" "-b" "we@pa.com" "-b" "www@dotcom.com" "felix@cat.ct" "yes"))
+                `("-s" "--" "-c" "mr@dont.play" "-b" "we@pa.com" "-b" "www@dotcom.com" "felix@cat.ct" "yes"))
     (check-mutt [mutt sample_msg #:to "arthur@frayn.zo" #:cc email_addrs #:bcc (list (string->path email_addrs))]
-                '("-s<no-subject>" "-c" "john@doe.com" "-c" "jane@doe.gov" "-b" "john@doe.com" "-b" "jane@doe.gov" "arthur@frayn.zo" "we" "trippy" "mane"))
+                `("-s" "<no-subject>" "-c" "john@doe.com" "-c" "jane@doe.gov" "-b" "john@doe.com" "-b" "jane@doe.gov" "arthur@frayn.zo" "we" "trippy" "mane"))
+
+    (let-values (((x log#) (mutt-interceptor
+                             (lambda ()
+                               (parameterize ((*mutt-exe-path* #false))
+                                 (mutt "You won't believe the \"quotes\"" #:to "anon@anon.net" #:subject "you won't believe"))))))
+      (check string-prefix? (car (hash-ref log# 'info))
+                            "mutt: send :: <mutt-exe> -s \"you won't believe\"   'anon@anon.net' < ")
+      (check-equal? (hash-ref log# 'warning)
+                    '("mutt: cannot send mail because parameter `*mutt-exe-path*` is `#f`")))
   )
+
 
   (test-case "mutt*"
     (check-mutt [mutt* (string->path sample_msg) #:to* email_addrs #:subject "fyi"]
-                '("-sfyi" "john@doe.com" "we" "trippy" "mane"
-                  "-sfyi" "jane@doe.gov" "we" "trippy" "mane"))
+                `("-s" "fyi" "john@doe.com" "we" "trippy" "mane"
+                  "-s" "fyi" "jane@doe.gov" "we" "trippy" "mane"))
   )
 
   (test-case "in-email*"

--- a/test/util.rkt
+++ b/test/util.rkt
@@ -1,0 +1,43 @@
+#lang typed/racket/base
+
+(provide
+  email_addrs
+  sample_msg
+  str+rx*=?
+  mutt-message-rx
+  mutt-interceptor)
+
+(require/typed mutt/private/main
+  (mutt-logger Logger))
+
+(require/typed make-log-interceptor
+  (make-log-interceptor
+    (-> Logger Log-Interceptor)))
+
+(define-type Log-Interceptor
+  (->* [(-> Any)]
+       [#:level Symbol
+        #:topic (U Symbol #false)]
+       (Values Any (HashTable Symbol Any))))
+
+;; -----------------------------------------------------------------------------
+
+(define email_addrs "./email_addrs.txt")
+(define sample_msg  "./sample_message.txt")
+(define mutt-message-rx #rx"mutt-message-[0-9].txt")
+
+(: str+rx*=? (-> (Listof String) (Listof (U String Regexp)) Boolean))
+(define (str+rx*=? a* b*)
+  (and (= (length a*) (length b*))
+       (for/and ((a (in-list a*))
+                 (b (in-list b*)))
+         (cond
+           [(string? b)
+            (string=? a b)]
+           [(regexp? b)
+            (regexp-match? b a)]
+           [else
+             #false]))))
+
+(: mutt-interceptor Log-Interceptor)
+(define mutt-interceptor (make-log-interceptor mutt-logger))


### PR DESCRIPTION
- use Racket's writer to escape strings in titles
- always save messages to files, to escape strings from bodies
  no more `echo` nonsense