### PR TITLE
at-exp compatibility

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 (define collection "mutt")
-(define deps '("base" "typed-racket-lib" "typed-racket-more" "make-log-interceptor"))
-(define build-deps '("scribble-lib" "racket-doc" "rackunit-lib" "rackunit-abbrevs" "typed-racket-doc"))
+(define deps '("base" "typed-racket-lib" "typed-racket-more" "make-log-interceptor" "scribble-lib"))
+(define build-deps '("scribble-doc" "scribble-lib" "racket-doc" "rackunit-lib" "rackunit-abbrevs" "typed-racket-doc"))
 (define pkg-desc "API for the Mutt email client")
 (define version "0.3")
 (define pkg-authors '(ben))

--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,7 @@
 (define deps '("base" "typed-racket-lib" "typed-racket-more" "make-log-interceptor" "scribble-lib"))
 (define build-deps '("scribble-doc" "scribble-lib" "racket-doc" "rackunit-lib" "rackunit-abbrevs" "typed-racket-doc"))
 (define pkg-desc "API for the Mutt email client")
-(define version "0.3")
+(define version "0.4")
 (define pkg-authors '(ben))
 (define scribblings '(("scribblings/mutt.scrbl" () ("Email"))))
 (define pre-install-collection "private/pre-install.rkt")

--- a/main.rkt
+++ b/main.rkt
@@ -5,6 +5,7 @@
   mutt/private/parameters
   racket/contract
   (only-in racket/sequence sequence/c)
+  (only-in scribble/core content?)
 )
 
 ;; -----------------------------------------------------------------------------
@@ -12,21 +13,23 @@
 (provide
   (contract-out
    [mutt
-    (->* [path-string?
+    (->* [(or/c path-string? string? pair?)
           #:to string?]
          [#:attachment attachment/c
           #:subject string?
           #:cc pre-email*/c
           #:bcc pre-email*/c]
+         #:rest content?
          boolean?)]
 
    [mutt*
-    (->* [path-string?
+    (->* [(or/c path-string? string? pair?)
           #:to* pre-email*/c]
          [#:attachment attachment/c
           #:subject string?
           #:cc pre-email*/c
           #:bcc pre-email*/c]
+         #:rest content?
          boolean?)]
 
    [in-email*

--- a/scribblings/mutt.scrbl
+++ b/scribblings/mutt.scrbl
@@ -3,7 +3,7 @@
   scribble/eval
   scriblib/footnote
   racket/contract
-  (for-label mutt racket/base racket/contract)
+  (for-label mutt racket/base racket/contract (only-in scribble/core content?))
 ]
 
 @title[#:tag "top"]{Mutt API}
@@ -81,7 +81,7 @@ Alternatively, the @racketmodname[mutt/setup] module provides a hook for reconfi
              (*mutt-exe-path* "xargs echo ")
              (current-output-port (open-output-nowhere)))))
 
-@defproc[(mutt [message path-string?]
+@defproc[(mutt [message (or/c path-string? content?)] ...+
                [#:to to email?]
                [#:subject subject string? (*mutt-default-subject*)]
                [#:cc cc pre-email*/c (*mutt-default-cc*)]
@@ -106,9 +106,25 @@ Alternatively, the @racketmodname[mutt/setup] module provides a hook for reconfi
           #:subject "10 Craziest YouTube Fails"
           #:cc "everyone@the.net")
   ]
+
+  Or, with the @racketmodname[at-exp] reader:
+
+  @codeblock[#:keep-lang-line? #true]|{
+    #lang at-exp racket/base
+    (require mutt racket/port)
+    (*mutt-exe-path* "xargs echo ")
+
+    (define name "Lizzo")
+
+    @mutt[#:to "lizzo@juice.net"
+          #:subject "truth"]{
+      Greetings @|name|,
+
+      How are you feeling today?}
+  }|
 }
 
-@defproc[(mutt* [message path-string?]
+@defproc[(mutt* [message (or/c path-string? content?)] ...+
                 [#:to* to pre-email*/c]
                 [#:subject subject string? (*mutt-default-subject*)]
                 [#:cc cc pre-email*/c (*mutt-default-cc*)]

--- a/test/typed.rkt
+++ b/test/typed.rkt
@@ -29,6 +29,8 @@
                 '("-s" "--" "-c" "mr@dont.play" "-b" "we@pa.com" "-b" "www@dotcom.com" "felix@cat.ct" "yes"))
     (check-mutt [mutt sample_msg #:to "arthur@frayn.zo" #:cc email_addrs #:bcc (list (string->path email_addrs))]
                 '("-s" "<no-subject>" "-c" "john@doe.com" "-c" "jane@doe.gov" "-b" "john@doe.com" "-b" "jane@doe.gov" "arthur@frayn.zo" "we" "trippy" "mane"))
+    (check-mutt [mutt "hello" #:to "adam@west.co" #:subject "hi" "and" " more"]
+                '("-s" "hi" "adam@west.co" "hello" "and" "more"))
 
     (let-values (((x log#) (mutt-interceptor
                              (lambda ()

--- a/test/untyped.rkt
+++ b/test/untyped.rkt
@@ -23,6 +23,8 @@
   (test-case "mutt"
     (check-mutt [mutt "hello" #:to "adam@west.co" #:subject "hi"]
                 `("-s" "hi" "adam@west.co" "hello"))
+    (check-mutt [mutt "hello" #:to "adam@west.co" #:subject "hi" "and" '("mo" ("re"))]
+                `("-s" "hi" "adam@west.co" "hello" "andmore"))
     (check-mutt [mutt "bye" #:to "mae@west.it" #:subject "yo" #:cc "a@a.a"]
                 `("-s" "yo" "-c" "a@a.a" "mae@west.it" "bye"))
     (check-mutt [mutt "yes" #:to "felix@cat.ct" #:subject "--" #:cc '("mr@dont.play") #:bcc '("we@pa.com" "www@dotcom.com")]
@@ -45,6 +47,9 @@
     (check-mutt [mutt* (string->path sample_msg) #:to* email_addrs #:subject "fyi"]
                 `("-s" "fyi" "john@doe.com" "we" "trippy" "mane"
                   "-s" "fyi" "jane@doe.gov" "we" "trippy" "mane"))
+    (check-mutt [mutt* (string->path sample_msg) #:to* email_addrs #:subject "fyi" "other" "args too"]
+                `("-s" "fyi" "john@doe.com" "we" "trippy" "mane" "otherargs" "too"
+                  "-s" "fyi" "jane@doe.gov" "we" "trippy" "mane" "otherargs" "too"))
   )
 
   (test-case "in-email*"

--- a/typed.rkt
+++ b/typed.rkt
@@ -1,19 +1,21 @@
 #lang typed/racket/base
 
 (require/typed/provide mutt/private/main
-  [mutt (->* [Path-String
+  [mutt (->* [(U Path-String (Listof String))
               #:to String]
              [#:subject String
               #:cc Pre-Email*
               #:bcc Pre-Email*
               #:attachment (U #f Path-String (Listof Path-String))]
+             #:rest String
              Boolean)]
-  [mutt* (->* [Path-String
+  [mutt* (->* [(U Path-String (Listof String))
                #:to* String]
               [#:subject String
                #:cc Pre-Email*
                #:bcc Pre-Email*
                #:attachment (U #f Path-String (Listof Path-String))]
+              #:rest String
               Boolean)]
   [in-email* (-> Pre-Email* (Listof String))]
   [email? (-> String (U #f String))])


### PR DESCRIPTION
Accept rest-arguments as Scribble `content?` so that
 `mutt` can be called nicely as at at-expression.

Also, relax the first argument to accept any content too

#19 