### PR TITLE
Accept tree of email addresses

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,7 @@
 (define deps '("base" "typed-racket-lib" "typed-racket-more" "make-log-interceptor" "scribble-lib"))
 (define build-deps '("scribble-doc" "scribble-lib" "racket-doc" "rackunit-lib" "rackunit-abbrevs" "typed-racket-doc"))
 (define pkg-desc "API for the Mutt email client")
-(define version "0.4")
+(define version "0.5")
 (define pkg-authors '(ben))
 (define scribblings '(("scribblings/mutt.scrbl" () ("Email"))))
 (define pre-install-collection "private/pre-install.rkt")

--- a/main.rkt
+++ b/main.rkt
@@ -14,7 +14,7 @@
   (contract-out
    [mutt
     (->* [(or/c path-string? string? pair?)
-          #:to string?]
+          #:to pre-email*/c]
          [#:attachment attachment/c
           #:subject string?
           #:cc pre-email*/c
@@ -67,6 +67,10 @@
 (define pre-email/c
   (or/c string? path-string?))
 
+(define (treeof elem-contract)
+  (or/c elem-contract
+        (listof (recursive-contract (treeof elem-contract) #:flat))))
+
 (define pre-email*/c
-  (or/c pre-email/c (listof pre-email/c)))
+  (treeof pre-email/c))
 

--- a/private/main.rkt
+++ b/private/main.rkt
@@ -23,13 +23,17 @@
 (define-logger mutt)
 
 (define (mutt msg
-              #:to to
+              #:to to*
               #:subject [subject (*mutt-default-subject*)]
-              #:cc [cc (*mutt-default-cc*)]
-              #:bcc [bcc (*mutt-default-bcc*)]
-              #:attachment [att* (*mutt-default-attachment*)]
+              #:cc [pre-cc (*mutt-default-cc*)]
+              #:bcc [pre-bcc (*mutt-default-bcc*)]
+              #:attachment [pre-att* (*mutt-default-attachment*)]
               . msg*)
-  (mutt/internal msg msg* to subject (in-email* cc) (in-email* bcc) (in-attach* att*)))
+  (define att* (in-attach* pre-att*))
+  (define cc (in-email* pre-cc))
+  (define bcc (in-email* pre-bcc))
+  (for/and ((to (in-email* to*)))
+    (mutt/internal msg msg* to subject cc bcc att*)))
 
 (define (mutt* msg
                #:to* to*
@@ -136,7 +140,7 @@
         (printf "[mutt] skipping invalid email address '~a'\n" v)
         (list)))]
    [else
-    (raise-argument-error 'in-email* "(or/c email? file-exists? (listof (or/c email? file-exists?)))" v)]))
+    (raise-argument-error 'in-email* "(treeof (or/c email? file-exists?))" v)]))
 
 (define (format-*cc emails prefix)
   (if (null? emails)

--- a/scribblings/mutt.scrbl
+++ b/scribblings/mutt.scrbl
@@ -122,6 +122,8 @@ Alternatively, the @racketmodname[mutt/setup] module provides a hook for reconfi
 
       How are you feeling today?}
   }|
+
+  @history[#:changed "0.4" @elem{Accept rest-args, for @racketmodname[at-exp] compatibility.}]
 }
 
 @defproc[(mutt* [message (or/c path-string? content?)] ...+

--- a/scribblings/mutt.scrbl
+++ b/scribblings/mutt.scrbl
@@ -82,13 +82,13 @@ Alternatively, the @racketmodname[mutt/setup] module provides a hook for reconfi
              (current-output-port (open-output-nowhere)))))
 
 @defproc[(mutt [message (or/c path-string? content?)] ...+
-               [#:to to email?]
+               [#:to to pre-email*/c]
                [#:subject subject string? (*mutt-default-subject*)]
                [#:cc cc pre-email*/c (*mutt-default-cc*)]
                [#:bcc bcc pre-email*/c (*mutt-default-bcc*)]
                [#:attachment attach* attachment/c (*mutt-default-attachment*)])
          boolean?]{
-  Send an email to the address @racket[to] with subject @racket[subject] and message body @racket[message].
+  Send an email to the address(es) @racket[to] with subject @racket[subject] and message body @racket[message].
   If @racket[message] is a filename, the email contains the contents of the file.
   Otherwise, the email contains the string @racket[message].
 
@@ -123,7 +123,9 @@ Alternatively, the @racketmodname[mutt/setup] module provides a hook for reconfi
       How are you feeling today?}
   }|
 
-  @history[#:changed "0.4" @elem{Accept rest-args, for @racketmodname[at-exp] compatibility.}]
+  @history[
+    #:changed "0.5" @elem{Accept tree of @racket[#:to] destination addresses.}
+    #:changed "0.4" @elem{Accept rest-args, for @racketmodname[at-exp] compatibility.}]
 }
 
 @defproc[(mutt* [message (or/c path-string? content?)] ...+
@@ -133,6 +135,9 @@ Alternatively, the @racketmodname[mutt/setup] module provides a hook for reconfi
                 [#:bcc bcc pre-email*/c (*mutt-default-bcc*)]
                 [#:attachment attach* attachment/c (*mutt-default-attachment*)])
          boolean?]{
+
+  @deprecated[#:what "function" @racket[mutt]]
+
   For each recipient address in @racket[to*], send an identical email message and include the same cc's, bcc's, and attachments.
 
   @examples[#:eval mutt-eval

--- a/scribblings/typed-mutt.scrbl
+++ b/scribblings/typed-mutt.scrbl
@@ -12,14 +12,14 @@ Typed clients should import the @racketmodname[mutt/typed] module.
 
 @deftogether[(
  @defthing[mutt (->* [Path-String
-                      #:to String]
+                      #:to Pre-Email*]
                      [#:subject String
                       #:cc Pre-Email*
                       #:bcc Pre-Email*
                       #:attachment (U #f Path-String (Listof Path-String))]
                      Boolean)]
  @defthing[mutt* (->* [Path-String
-                       #:to String]
+                       #:to Pre-Email*]
                       [#:subject String
                        #:cc Pre-Email*
                        #:bcc Pre-Email*

--- a/test/untyped.rkt
+++ b/test/untyped.rkt
@@ -44,10 +44,10 @@
 
 
   (test-case "mutt*"
-    (check-mutt [mutt* (string->path sample_msg) #:to* email_addrs #:subject "fyi"]
+    (check-mutt [mutt (string->path sample_msg) #:to email_addrs #:subject "fyi"]
                 `("-s" "fyi" "john@doe.com" "we" "trippy" "mane"
                   "-s" "fyi" "jane@doe.gov" "we" "trippy" "mane"))
-    (check-mutt [mutt* (string->path sample_msg) #:to* email_addrs #:subject "fyi" "other" "args too"]
+    (check-mutt [mutt (string->path sample_msg) #:to email_addrs #:subject "fyi" "other" "args too"]
                 `("-s" "fyi" "john@doe.com" "we" "trippy" "mane" "otherargs" "too"
                   "-s" "fyi" "jane@doe.gov" "we" "trippy" "mane" "otherargs" "too"))
   )

--- a/typed.rkt
+++ b/typed.rkt
@@ -2,7 +2,7 @@
 
 (require/typed/provide mutt/private/main
   [mutt (->* [(U Path-String (Listof String))
-              #:to String]
+              #:to Pre-Email*]
              [#:subject String
               #:cc Pre-Email*
               #:bcc Pre-Email*
@@ -10,7 +10,7 @@
              #:rest String
              Boolean)]
   [mutt* (->* [(U Path-String (Listof String))
-               #:to* String]
+               #:to* Pre-Email*]
               [#:subject String
                #:cc Pre-Email*
                #:bcc Pre-Email*


### PR DESCRIPTION
Change `mutt` to accept a tree of `#:to` addresses, deprecate `mutt*`